### PR TITLE
fixed example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,21 @@ $apiCredentials = Api\Credentials::create('https://your.akeneo.host/', 'clientId
 $loader = $factory->createByCredentials($apiCredentials);
 
 $loader->load('product', [
-
-    'identifier' => 'test-product',
-    'enabled'    => true,
-    'family'     => 'accessories',
-    'categories' => [
-        'master_accessories',
-        'print_accessories',
-        'suppliers',
-    ],
-    'values' => [
-        'ean'    => [[ 'locale' =>  null, 'scope' =>  null, 'data' => '1234567890183' ]],
-        'name'   => [[ 'locale' =>  null, 'scope' =>  null, 'data' => 'Test product' ]],
-        'image'  => [[ 'locale' =>  null, 'scope' =>  null, 'data' => '@file:asset/1111111171.jpg' ]],
-        'weight' => [[ 'locale' =>  null, 'scope' =>  null, 'data' => [ 'amount' =>  '500.0000', 'unit' => 'GRAM' ] ]],
+    [
+        'identifier' => 'test-product',
+        'enabled'    => true,
+        'family'     => 'accessories',
+        'categories' => [
+            'master_accessories',
+            'print_accessories',
+            'suppliers',
+        ],
+        'values' => [
+            'ean'    => [[ 'locale' =>  null, 'scope' =>  null, 'data' => '1234567890183' ]],
+            'name'   => [[ 'locale' =>  null, 'scope' =>  null, 'data' => 'Test product' ]],
+            'image'  => [[ 'locale' =>  null, 'scope' =>  null, 'data' => '@file:asset/1111111171.jpg' ]],
+            'weight' => [[ 'locale' =>  null, 'scope' =>  null, 'data' => [ 'amount' =>  '500.0000', 'unit' => 'GRAM' ] ]],
+        ],
     ],
 ]);
 ```


### PR DESCRIPTION
Hello and thank you for such a great lib! 

The example in README file seems to be outdated. When we try to run the code, we got the following error:
```php
PHP Fatal error:  Uncaught Akeneo\Pim\ApiClient\Exception\InvalidArgumentException: The parameter "resources" must be an array of array. in /home/bagger/src/akeneo-data-loader/vendor/akeneo/api-php-client/src/Client/ResourceClient.php:162
Stack trace:
#0 /home/bagger/src/akeneo-data-loader/vendor/akeneo/api-php-client/src/Api/ProductApi.php(113): Akeneo\Pim\ApiClient\Client\ResourceClient->upsertStreamResourceList('api/rest/v1/pro...', Array, Array)
#1 /home/bagger/src/akeneo-data-loader/src/Api/Connector/Product.php(47): Akeneo\Pim\ApiClient\Api\ProductApi->upsertList(Array)
#2 /home/bagger/src/akeneo-data-loader/src/Loader.php(76): Aa\AkeneoDataLoader\Api\Connector\Product->upload(Array)
#3 /home/bagger/src/akeneo-data-loader/src/Loader.php(44): Aa\AkeneoDataLoader\Loader->uploadBatchesAndValidate(Object(Aa\AkeneoDataLoader\Api\Connector\Product), Object(Generator))
#4 /home/bagger/src/akeneo-data-loader/load.php(15): Aa\AkeneoDataLoader\Loader->load('product', Array)
#5 {main}
  thrown in /home/bagger/src/akeneo-data-loader/vendor/akeneo/api-php-client/src/Client/ResourceClient.php on line 162
```
It seems, "load()" method accepts an array of arrays as a data. The PR fixes the docs.